### PR TITLE
Fixed NPE for the cases when signature producion data is missing.

### DIFF
--- a/src/org/digidoc4j/Container.java
+++ b/src/org/digidoc4j/Container.java
@@ -58,6 +58,8 @@ public interface Container extends Serializable {
 
   DataFile addDataFile(File file, String mimeType);
 
+  void addDataFile(DataFile dataFile);
+
   void addSignature(Signature signature);
 
   /**

--- a/src/org/digidoc4j/exceptions/InvalidDataFileException.java
+++ b/src/org/digidoc4j/exceptions/InvalidDataFileException.java
@@ -1,0 +1,18 @@
+/* DigiDoc4J library
+*
+* This software is released under either the GNU Library General Public
+* License (see LICENSE.LGPL).
+*
+* Note that the only valid version of the LGPL license as far as this
+* project is concerned is the original GNU Library General Public License
+* Version 2.1, February 1999
+*/
+
+package org.digidoc4j.exceptions;
+
+public class InvalidDataFileException extends DigiDoc4JException {
+
+  public InvalidDataFileException(String message) {
+    super(message);
+  }
+}

--- a/src/org/digidoc4j/impl/bdoc/BDocContainer.java
+++ b/src/org/digidoc4j/impl/bdoc/BDocContainer.java
@@ -59,6 +59,11 @@ public class BDocContainer implements Container {
   }
 
   @Override
+  public void addDataFile(DataFile dataFile) {
+    asicFacade.addDataFile(dataFile);
+  }
+
+  @Override
   public void addSignature(Signature signature) {
     asicFacade.addSignature(signature);
   }

--- a/src/org/digidoc4j/impl/ddoc/DDocContainer.java
+++ b/src/org/digidoc4j/impl/ddoc/DDocContainer.java
@@ -66,6 +66,11 @@ public class DDocContainer implements Container {
   }
 
   @Override
+  public void addDataFile(DataFile dataFile) {
+    jDigiDocFacade.addDataFile(dataFile);
+  }
+
+  @Override
   public void addSignature(Signature signature) {
     logger.debug("Ignoring separate add signature call for DDoc containers, because signatures are added to container during signing process");
   }

--- a/src/org/digidoc4j/impl/ddoc/DDocFacade.java
+++ b/src/org/digidoc4j/impl/ddoc/DDocFacade.java
@@ -265,6 +265,10 @@ public class DDocFacade implements SignatureFinalizer, Serializable {
     }
   }
 
+  public void addDataFile(DataFile dataFile) {
+    addDataFile(dataFile.getStream(), dataFile.getName(), dataFile.getMediaType());
+  }
+
   public void addRawSignature(byte[] signatureBytes) {
     logger.debug("");
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(signatureBytes);

--- a/src/org/digidoc4j/impl/ddoc/DDocSignature.java
+++ b/src/org/digidoc4j/impl/ddoc/DDocSignature.java
@@ -52,13 +52,25 @@ public class DDocSignature implements Signature {
   @Override
   public String getCity() {
     logger.debug("");
-    return origin.getSignedProperties().getSignatureProductionPlace().getCity();
+    
+    String city = null;
+    if (origin.getSignedProperties().getSignatureProductionPlace() != null) {
+      city = origin.getSignedProperties().getSignatureProductionPlace().getCity();
+    }
+    
+    return city;
   }
 
   @Override
   public String getCountryName() {
     logger.debug("");
-    return origin.getSignedProperties().getSignatureProductionPlace().getCountryName();
+    
+    String countryName = null;
+    if (origin.getSignedProperties().getSignatureProductionPlace() != null) {
+      countryName = origin.getSignedProperties().getSignatureProductionPlace().getCountryName();
+    }
+    
+    return countryName;
   }
 
   @Override
@@ -89,7 +101,13 @@ public class DDocSignature implements Signature {
   @Override
   public String getPostalCode() {
     logger.debug("");
-    return origin.getSignedProperties().getSignatureProductionPlace().getPostalCode();
+    
+    String postalCode = null;
+    if (origin.getSignedProperties().getSignatureProductionPlace() != null) {
+      postalCode = origin.getSignedProperties().getSignatureProductionPlace().getPostalCode();
+    }
+    
+    return postalCode;
   }
 
   @Override
@@ -157,7 +175,13 @@ public class DDocSignature implements Signature {
   @Override
   public String getStateOrProvince() {
     logger.debug("");
-    return origin.getSignedProperties().getSignatureProductionPlace().getStateOrProvince();
+    
+    String stateOrProvince = null;
+    if (origin.getSignedProperties().getSignatureProductionPlace() != null) {
+      stateOrProvince = origin.getSignedProperties().getSignatureProductionPlace().getStateOrProvince();;
+    }
+    
+    return stateOrProvince;
   }
 
   @Override

--- a/test/org/digidoc4j/testutils/TestContainer.java
+++ b/test/org/digidoc4j/testutils/TestContainer.java
@@ -99,6 +99,10 @@ public class TestContainer implements Container {
   }
 
   @Override
+  public void addDataFile(DataFile dataFile) {
+  }
+
+  @Override
   public void addSignature(Signature signature) {
 
   }


### PR DESCRIPTION
We must check for `null` when fetching signature production data from a `DDocSignature`, because _SignatureProductionPlace_ element is OPTIONAL according to the [XAdES specification](http://www.w3.org/TR/XAdES/#Syntax_overview_The_QualifyingProperties_SignedSignatureProperties).

Concrete use case where I have encountered this issue: opening a container from a DigiDoc file with a signature that had no location data. After getting the signature from this container and trying to get some signature production data (e.g. _signature.getCity()_) a _NullPointerException_ was thrown.