### PR TITLE
make 'logger' declarations consistent (final static)

### DIFF
--- a/src/eu/europa/ec/markt/dss/signature/StreamDocument.java
+++ b/src/eu/europa/ec/markt/dss/signature/StreamDocument.java
@@ -25,7 +25,7 @@ import java.io.*;
  * files.
  */
 public class StreamDocument implements DSSDocument {
-  final Logger logger = LoggerFactory.getLogger(StreamDocument.class);
+  final static Logger logger = LoggerFactory.getLogger(StreamDocument.class);
 
   private static final int MAX_SIZE_IN_MEMORY = 1024 * 5;
   String documentName;

--- a/src/eu/europa/ec/markt/dss/validation102853/https/DigiDoc4JDataLoader.java
+++ b/src/eu/europa/ec/markt/dss/validation102853/https/DigiDoc4JDataLoader.java
@@ -22,7 +22,7 @@ import java.net.URL;
  *
  */
 public class DigiDoc4JDataLoader extends CommonsDataLoader {
-  Logger logger = LoggerFactory.getLogger(DigiDoc4JDataLoader.class);
+  final static Logger logger = LoggerFactory.getLogger(DigiDoc4JDataLoader.class);
 
   @Override
   public byte[] get(String urlString) throws DSSCannotFetchDataException {

--- a/src/eu/europa/ec/markt/dss/validation102853/ocsp/BDocTMOcspSource.java
+++ b/src/eu/europa/ec/markt/dss/validation102853/ocsp/BDocTMOcspSource.java
@@ -19,7 +19,7 @@ import static eu.europa.ec.markt.dss.DSSUtils.digest;
 import static org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers.id_pkix_ocsp_nonce;
 
 public class BDocTMOcspSource extends SKOnlineOCSPSource {
-  final Logger logger = LoggerFactory.getLogger(SKOnlineOCSPSource.class);
+  final static Logger logger = LoggerFactory.getLogger(SKOnlineOCSPSource.class);
   private final byte[] signature;
 
   public BDocTMOcspSource(Configuration configuration, byte[] signature) {

--- a/src/eu/europa/ec/markt/dss/validation102853/ocsp/SKOnlineOCSPSource.java
+++ b/src/eu/europa/ec/markt/dss/validation102853/ocsp/SKOnlineOCSPSource.java
@@ -50,7 +50,7 @@ import java.util.List;
 * SK OCSP source location.
 */
 public abstract class SKOnlineOCSPSource implements OCSPSource {
-  final Logger logger = LoggerFactory.getLogger(SKOnlineOCSPSource.class);
+  final static Logger logger = LoggerFactory.getLogger(SKOnlineOCSPSource.class);
 
   // TODO: A hack for testing, to be removed later
   public static volatile Listener listener = null;

--- a/src/org/digidoc4j/Configuration.java
+++ b/src/org/digidoc4j/Configuration.java
@@ -114,7 +114,7 @@ import static org.apache.commons.lang.StringUtils.isNotEmpty;
  */
 public class Configuration implements Serializable {
   private static final int ONE_SECOND = 1000;
-  final Logger logger = LoggerFactory.getLogger(Configuration.class);
+  final static Logger logger = LoggerFactory.getLogger(Configuration.class);
   public static final long ONE_MB_IN_BYTES = 1048576;
 
   public static final String DEFAULT_CANONICALIZATION_FACTORY_IMPLEMENTATION

--- a/src/org/digidoc4j/DataFile.java
+++ b/src/org/digidoc4j/DataFile.java
@@ -30,7 +30,7 @@ import java.nio.file.Paths;
  * Data file wrapper providing methods for handling signed files or files to be signed in Container.
  */
 public class DataFile implements Serializable {
-  final Logger logger = LoggerFactory.getLogger(DataFile.class);
+  final static Logger logger = LoggerFactory.getLogger(DataFile.class);
 
   DSSDocument document = null;
   private Digest digest = null;

--- a/src/org/digidoc4j/SignatureProductionPlace.java
+++ b/src/org/digidoc4j/SignatureProductionPlace.java
@@ -11,6 +11,7 @@
 package org.digidoc4j;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 
@@ -19,7 +20,7 @@ import java.io.Serializable;
  * @deprecated use {@link org.digidoc4j.SignatureParameters} instead.
  */
 public class SignatureProductionPlace implements Serializable {
-  Logger logger = org.slf4j.LoggerFactory.getLogger(SignatureProductionPlace.class);
+  final static Logger logger = LoggerFactory.getLogger(SignatureProductionPlace.class);
   private String city;
   private String stateOrProvince;
   private String postalCode;

--- a/src/org/digidoc4j/X509Cert.java
+++ b/src/org/digidoc4j/X509Cert.java
@@ -35,7 +35,7 @@ import java.util.*;
  * Wrapper for java.security.cert.X509Certificate object.
  */
 public class X509Cert implements Serializable {
-  Logger logger = LoggerFactory.getLogger(X509Cert.class);
+  final static Logger logger = LoggerFactory.getLogger(X509Cert.class);
   private X509Certificate originalCert;
   private Map<String, String> issuerPartMap;
   private Map<String, String> subjectNamePartMap;

--- a/src/org/digidoc4j/impl/bdoc/ManifestEntry.java
+++ b/src/org/digidoc4j/impl/bdoc/ManifestEntry.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * Contains information of filenames and mimetypes.
  */
 public final class ManifestEntry {
-  final Logger logger = LoggerFactory.getLogger(ManifestEntry.class);
+  final static Logger logger = LoggerFactory.getLogger(ManifestEntry.class);
   private String fileName;
   private String mimeType;
 

--- a/src/org/digidoc4j/impl/ddoc/DDocFacade.java
+++ b/src/org/digidoc4j/impl/ddoc/DDocFacade.java
@@ -48,7 +48,7 @@ import static ee.sk.digidoc.DataFile.CONTENT_EMBEDDED_BASE64;
  * </p>
  */
 public class DDocFacade implements SignatureFinalizer, Serializable {
-  Logger logger = LoggerFactory.getLogger(DDocFacade.class);
+  final static Logger logger = LoggerFactory.getLogger(DDocFacade.class);
 
   SignedDoc ddoc;
   private ArrayList<DigiDocException> openContainerExceptions = new ArrayList<>();

--- a/src/org/digidoc4j/impl/ddoc/DDocSignature.java
+++ b/src/org/digidoc4j/impl/ddoc/DDocSignature.java
@@ -30,7 +30,7 @@ import org.digidoc4j.SignatureProfile;
  * corresponding OCSP response properties.
  */
 public class DDocSignature implements Signature {
-  final Logger logger = LoggerFactory.getLogger(DDocSignature.class);
+  final static Logger logger = LoggerFactory.getLogger(DDocSignature.class);
   private X509Cert certificate;
   private final ee.sk.digidoc.Signature origin;
   private int indexInArray;

--- a/src/org/digidoc4j/signers/PKCS12SignatureToken.java
+++ b/src/org/digidoc4j/signers/PKCS12SignatureToken.java
@@ -25,7 +25,7 @@ import java.security.cert.X509Certificate;
  * Implements PKCS12 signer.
  */
 public class PKCS12SignatureToken implements SignatureToken {
-  final Logger logger = LoggerFactory.getLogger(PKCS12SignatureToken.class);
+  final static Logger logger = LoggerFactory.getLogger(PKCS12SignatureToken.class);
   protected AbstractSignatureTokenConnection signatureTokenConnection = null;
   protected DSSPrivateKeyEntry keyEntry = null;
 

--- a/src/prototype/TestSignatureToken.java
+++ b/src/prototype/TestSignatureToken.java
@@ -23,7 +23,7 @@ import eu.europa.ec.markt.dss.DSSUtils;
 
 public class TestSignatureToken extends PKCS12SignatureToken {
 
-  final Logger logger = LoggerFactory.getLogger(TestSignatureToken.class);
+  final static Logger logger = LoggerFactory.getLogger(TestSignatureToken.class);
 
   public TestSignatureToken(String fileName, char[] password) {
     super(fileName, password);


### PR DESCRIPTION
Makes serializable objects usable with any slf4j binding. Currently Configuration.copy() fails with java.io.NotSerializableException when using [Grails](https://grails.org/) log4j plugin.
