### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -14,7 +14,7 @@
     <dependency org="commons-codec" name="commons-codec" rev="[1.9,2[" conf="runtime->default"/>
     <dependency org="commons-lang" name="commons-lang" rev="[2.6,2.7[" conf="runtime->default"/>
     <dependency org="commons-logging" name="commons-logging" rev="[1.1,1.2[" conf="runtime->default"/>
-    <dependency org="commons-collections" name="commons-collections" rev="3.2.1" conf="runtime->default"/>
+    <dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="runtime->default"/>
     <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.3.+" conf="runtime->default"/>
     <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.3.+" conf="runtime->default"/>
     <dependency org="org.apache.santuario" name="xmlsec" rev="[2.0,2.1[" conf="runtime->default"/>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/