### PR TITLE
Possibility to provide custom data loaders

### DIFF
--- a/src/org/digidoc4j/Configuration.java
+++ b/src/org/digidoc4j/Configuration.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang.StringUtils;
 import org.digidoc4j.exceptions.ConfigurationException;
 import org.digidoc4j.exceptions.DigiDoc4JException;
 import org.digidoc4j.impl.ConfigurationSingeltonHolder;
+import org.digidoc4j.impl.bdoc.dataloader.DataLoaderFactory;
 import org.digidoc4j.impl.bdoc.tsl.TslManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,6 +183,9 @@ public class Configuration implements Serializable {
   private String sslTruststorePath;
   private String sslTruststoreType;
   private String sslTruststorePassword;
+  private DataLoaderFactory ocspDataLoaderFactory;
+  private DataLoaderFactory timestampDataLoaderFactory;
+  private DataLoaderFactory tslDataLoaderFactory;
   private transient ExecutorService threadExecutor;
 
   /**
@@ -1174,12 +1178,52 @@ public class Configuration implements Serializable {
     return sslTruststorePassword;
   }
 
+  /**
+   * Set an executor service that handles validation of signatures in multiple threads.
+   * @param threadExecutor signature validation thread executor.
+   */
   public void setThreadExecutor(ExecutorService threadExecutor) {
     this.threadExecutor = threadExecutor;
   }
 
   public ExecutorService getThreadExecutor() {
     return threadExecutor;
+  }
+
+  /**
+   * Set a data loader factory that manages the creation of data loaders for creating OCSP requests.
+   * @param ocspDataLoaderFactory ocsp data loader factory.
+   */
+  public void setOcspDataLoaderFactory(DataLoaderFactory ocspDataLoaderFactory) {
+    this.ocspDataLoaderFactory = ocspDataLoaderFactory;
+  }
+
+  public DataLoaderFactory getOcspDataLoaderFactory() {
+    return ocspDataLoaderFactory;
+  }
+
+  /**
+   * Set a data loader factory that manages the creation of data loaders for creating TimeStamp requests.
+   * @param timestampDataLoaderFactory timestamp data loader factory.
+   */
+  public void setTimestampDataLoaderFactory(DataLoaderFactory timestampDataLoaderFactory) {
+    this.timestampDataLoaderFactory = timestampDataLoaderFactory;
+  }
+
+  public DataLoaderFactory getTimestampDataLoaderFactory() {
+    return timestampDataLoaderFactory;
+  }
+
+  /**
+   * Set a data loader factory that manages the creation of data loaders for downloading TSL.
+   * @param tslDataLoaderFactory TSL data loader factory.
+   */
+  public void setTslDataLoaderFactory(DataLoaderFactory tslDataLoaderFactory) {
+    this.tslDataLoaderFactory = tslDataLoaderFactory;
+  }
+
+  public DataLoaderFactory getTslDataLoaderFactory() {
+    return tslDataLoaderFactory;
   }
 
   /**

--- a/src/org/digidoc4j/impl/bdoc/BDocSignatureBuilder.java
+++ b/src/org/digidoc4j/impl/bdoc/BDocSignatureBuilder.java
@@ -39,6 +39,7 @@ import org.digidoc4j.exceptions.OCSPRequestFailedException;
 import org.digidoc4j.exceptions.SignerCertificateRequiredException;
 import org.digidoc4j.impl.SignatureFinalizer;
 import org.digidoc4j.impl.bdoc.asic.DetachedContentCreator;
+import org.digidoc4j.impl.bdoc.dataloader.TimeStampDataLoaderFactory;
 import org.digidoc4j.impl.bdoc.ocsp.SKOnlineOCSPSource;
 import org.digidoc4j.impl.bdoc.xades.XadesSignature;
 import org.digidoc4j.impl.bdoc.xades.XadesSigningDssFacade;
@@ -50,6 +51,7 @@ import eu.europa.esig.dss.DSSUtils;
 import eu.europa.esig.dss.InMemoryDocument;
 import eu.europa.esig.dss.Policy;
 import eu.europa.esig.dss.SignerLocation;
+import eu.europa.esig.dss.client.http.DataLoader;
 import eu.europa.esig.dss.client.tsp.OnlineTSPSource;
 
 public class BDocSignatureBuilder extends SignatureBuilder implements SignatureFinalizer {
@@ -188,8 +190,7 @@ public class BDocSignatureBuilder extends SignatureBuilder implements SignatureF
   private void setTimeStampProviderSource() {
     Configuration configuration = getConfiguration();
     OnlineTSPSource tspSource = new OnlineTSPSource(configuration.getTspSource());
-    SkDataLoader dataLoader = SkDataLoader.createTimestampDataLoader(configuration);
-    dataLoader.setUserAgentSignatureProfile(signatureParameters.getSignatureProfile());
+    DataLoader dataLoader = new TimeStampDataLoaderFactory(configuration, signatureParameters.getSignatureProfile()).create();
     tspSource.setDataLoader(dataLoader);
     facade.setTspSource(tspSource);
   }

--- a/src/org/digidoc4j/impl/bdoc/dataloader/DataLoaderFactory.java
+++ b/src/org/digidoc4j/impl/bdoc/dataloader/DataLoaderFactory.java
@@ -1,0 +1,30 @@
+/* DigiDoc4J library
+*
+* This software is released under either the GNU Library General Public
+* License (see LICENSE.LGPL).
+*
+* Note that the only valid version of the LGPL license as far as this
+* project is concerned is the original GNU Library General Public License
+* Version 2.1, February 1999
+*/
+
+package org.digidoc4j.impl.bdoc.dataloader;
+
+import java.io.Serializable;
+
+import eu.europa.esig.dss.client.http.DataLoader;
+
+/**
+ * Manages the creation of new data loaders. Data loaders are used in getting OCSP and TimeStamp requests and
+ * downloading certificates from the Trusted List (TSL).
+ */
+public interface DataLoaderFactory extends Serializable {
+
+  /**
+   * Create a new data loader instance.
+   *
+   * @return new data loader.
+   */
+  DataLoader create();
+
+}

--- a/src/org/digidoc4j/impl/bdoc/dataloader/OcspDataLoaderFactory.java
+++ b/src/org/digidoc4j/impl/bdoc/dataloader/OcspDataLoaderFactory.java
@@ -1,0 +1,51 @@
+/* DigiDoc4J library
+*
+* This software is released under either the GNU Library General Public
+* License (see LICENSE.LGPL).
+*
+* Note that the only valid version of the LGPL license as far as this
+* project is concerned is the original GNU Library General Public License
+* Version 2.1, February 1999
+*/
+
+package org.digidoc4j.impl.bdoc.dataloader;
+
+import org.digidoc4j.Configuration;
+import org.digidoc4j.SignatureProfile;
+import org.digidoc4j.impl.bdoc.SkDataLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.europa.esig.dss.client.http.DataLoader;
+
+/**
+ * Manages the creation of new data loaders for getting OCSP responses.
+ */
+public class OcspDataLoaderFactory implements DataLoaderFactory {
+
+  private static final Logger logger = LoggerFactory.getLogger(OcspDataLoaderFactory.class);
+  private Configuration configuration;
+  private SignatureProfile signatureProfile;
+
+  public OcspDataLoaderFactory(Configuration configuration, SignatureProfile signatureProfile) {
+    this.configuration = configuration;
+    this.signatureProfile = signatureProfile;
+  }
+
+  @Override
+  public DataLoader create() {
+    if (configuration.getOcspDataLoaderFactory() == null) {
+      return createDataLoader();
+    } else {
+      logger.debug("Using custom ocsp data loader factory provided by the configuration");
+      return configuration.getOcspDataLoaderFactory().create();
+    }
+  }
+
+  protected DataLoader createDataLoader() {
+    logger.debug("Creating OCSP data loader");
+    SkDataLoader dataLoader = SkDataLoader.createOcspDataLoader(configuration);
+    dataLoader.setUserAgentSignatureProfile(signatureProfile);
+    return dataLoader;
+  }
+}

--- a/src/org/digidoc4j/impl/bdoc/dataloader/TimeStampDataLoaderFactory.java
+++ b/src/org/digidoc4j/impl/bdoc/dataloader/TimeStampDataLoaderFactory.java
@@ -1,0 +1,51 @@
+/* DigiDoc4J library
+*
+* This software is released under either the GNU Library General Public
+* License (see LICENSE.LGPL).
+*
+* Note that the only valid version of the LGPL license as far as this
+* project is concerned is the original GNU Library General Public License
+* Version 2.1, February 1999
+*/
+
+package org.digidoc4j.impl.bdoc.dataloader;
+
+import org.digidoc4j.Configuration;
+import org.digidoc4j.SignatureProfile;
+import org.digidoc4j.impl.bdoc.SkDataLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.europa.esig.dss.client.http.DataLoader;
+
+/**
+ * Manages the creation of data loaders for getting TimeStamp responses.
+ */
+public class TimeStampDataLoaderFactory implements DataLoaderFactory {
+
+  private static final Logger logger = LoggerFactory.getLogger(TimeStampDataLoaderFactory.class);
+  private Configuration configuration;
+  private SignatureProfile signatureProfile;
+
+  public TimeStampDataLoaderFactory(Configuration configuration, SignatureProfile signatureProfile) {
+    this.configuration = configuration;
+    this.signatureProfile = signatureProfile;
+  }
+
+  @Override
+  public DataLoader create() {
+    if (configuration.getTimestampDataLoaderFactory() == null) {
+      return createDataLoader();
+    } else {
+      logger.debug("Using custom Timestamp data loader factory provided by the configuration");
+      return configuration.getTimestampDataLoaderFactory().create();
+    }
+  }
+
+  protected DataLoader createDataLoader() {
+    logger.debug("Creating Timestamp data loader");
+    SkDataLoader dataLoader = SkDataLoader.createTimestampDataLoader(configuration);
+    dataLoader.setUserAgentSignatureProfile(signatureProfile);
+    return dataLoader;
+  }
+}

--- a/src/org/digidoc4j/impl/bdoc/dataloader/TslDataLoaderFactory.java
+++ b/src/org/digidoc4j/impl/bdoc/dataloader/TslDataLoaderFactory.java
@@ -1,0 +1,61 @@
+/* DigiDoc4J library
+*
+* This software is released under either the GNU Library General Public
+* License (see LICENSE.LGPL).
+*
+* Note that the only valid version of the LGPL license as far as this
+* project is concerned is the original GNU Library General Public License
+* Version 2.1, February 1999
+*/
+
+package org.digidoc4j.impl.bdoc.dataloader;
+
+import java.io.File;
+
+import org.digidoc4j.Configuration;
+import org.digidoc4j.impl.bdoc.CachingDataLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.europa.esig.dss.client.http.DataLoader;
+import eu.europa.esig.dss.client.http.Protocol;
+import eu.europa.esig.dss.client.http.commons.CommonsDataLoader;
+
+/**
+ * Manages the creation of data loaders for downloading certificates from the Trust Store (TSL).
+ */
+public class TslDataLoaderFactory implements DataLoaderFactory {
+
+  private static final Logger logger = LoggerFactory.getLogger(TslDataLoaderFactory.class);
+  private Configuration configuration;
+  private File fileCacheDirectory;
+
+  public TslDataLoaderFactory(Configuration configuration, File fileCacheDirectory) {
+    this.configuration = configuration;
+    this.fileCacheDirectory = fileCacheDirectory;
+  }
+
+  @Override
+  public DataLoader create() {
+    if (configuration.getTslDataLoaderFactory() == null) {
+      return createDataLoader();
+    } else {
+      logger.debug("Using custom tsl data loader factory provided by the configuration");
+      return configuration.getTslDataLoaderFactory().create();
+    }
+  }
+
+  protected DataLoader createDataLoader() {
+    if (Protocol.isHttpUrl(configuration.getTslLocation())) {
+      CachingDataLoader dataLoader = new CachingDataLoader(configuration);
+      dataLoader.setTimeoutConnection(configuration.getConnectionTimeout());
+      dataLoader.setTimeoutSocket(configuration.getSocketTimeout());
+      dataLoader.setCacheExpirationTime(configuration.getTslCacheExpirationTime());
+      dataLoader.setFileCacheDirectory(fileCacheDirectory);
+      logger.debug("Using file cache directory for storing TSL: " + fileCacheDirectory);
+      return dataLoader;
+    } else {
+      return new CommonsDataLoader();
+    }
+  }
+}

--- a/src/org/digidoc4j/impl/bdoc/ocsp/OcspSourceBuilder.java
+++ b/src/org/digidoc4j/impl/bdoc/ocsp/OcspSourceBuilder.java
@@ -12,10 +12,15 @@ package org.digidoc4j.impl.bdoc.ocsp;
 
 import org.digidoc4j.Configuration;
 import org.digidoc4j.SignatureProfile;
-import org.digidoc4j.impl.bdoc.SkDataLoader;
+import org.digidoc4j.impl.bdoc.dataloader.OcspDataLoaderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.europa.esig.dss.client.http.DataLoader;
 
 public class OcspSourceBuilder {
 
+  private static final Logger logger = LoggerFactory.getLogger(OcspSourceBuilder.class);
   private Configuration configuration;
   private byte[] signatureValue;
   private SignatureProfile signatureProfile;
@@ -25,14 +30,14 @@ public class OcspSourceBuilder {
   }
 
   public SKOnlineOCSPSource build() {
+    logger.debug("Building SK Online OCSP source");
     SKOnlineOCSPSource ocspSource;
     if (signatureProfile == SignatureProfile.LT_TM) {
       ocspSource = new BDocTMOcspSource(configuration, signatureValue);
     } else {
       ocspSource = new BDocTSOcspSource(configuration);
     }
-    SkDataLoader dataLoader = SkDataLoader.createOcspDataLoader(configuration);
-    dataLoader.setUserAgentSignatureProfile(signatureProfile);
+    DataLoader dataLoader = new OcspDataLoaderFactory(configuration, signatureProfile).create();
     ocspSource.setDataLoader(dataLoader);
     return ocspSource;
   }

--- a/src/org/digidoc4j/impl/bdoc/tsl/TslLoader.java
+++ b/src/org/digidoc4j/impl/bdoc/tsl/TslLoader.java
@@ -22,14 +22,12 @@ import org.digidoc4j.Configuration;
 import org.digidoc4j.exceptions.DigiDoc4JException;
 import org.digidoc4j.exceptions.TslCertificateSourceInitializationException;
 import org.digidoc4j.exceptions.TslKeyStoreNotFoundException;
-import org.digidoc4j.impl.bdoc.CachingDataLoader;
+import org.digidoc4j.impl.bdoc.dataloader.TslDataLoaderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import eu.europa.esig.dss.DSSException;
 import eu.europa.esig.dss.client.http.DataLoader;
-import eu.europa.esig.dss.client.http.Protocol;
-import eu.europa.esig.dss.client.http.commons.CommonsDataLoader;
 import eu.europa.esig.dss.tsl.service.TSLRepository;
 import eu.europa.esig.dss.tsl.service.TSLValidationJob;
 import eu.europa.esig.dss.x509.KeyStoreCertificateSource;
@@ -104,17 +102,7 @@ public class TslLoader implements Serializable {
   }
 
   private DataLoader createDataLoader() {
-    if (Protocol.isHttpUrl(configuration.getTslLocation())) {
-      CachingDataLoader dataLoader = new CachingDataLoader(configuration);
-      dataLoader.setTimeoutConnection(configuration.getConnectionTimeout());
-      dataLoader.setTimeoutSocket(configuration.getSocketTimeout());
-      dataLoader.setCacheExpirationTime(configuration.getTslCacheExpirationTime());
-      dataLoader.setFileCacheDirectory(fileCacheDirectory);
-      logger.debug("Using file cache directory for storing TSL: " + fileCacheDirectory);
-      return dataLoader;
-    } else {
-      return new CommonsDataLoader();
-    }
+    return new TslDataLoaderFactory(configuration, fileCacheDirectory).create();
   }
 
   private KeyStoreCertificateSource getKeyStore() {

--- a/src/org/digidoc4j/impl/bdoc/xades/SignatureExtender.java
+++ b/src/org/digidoc4j/impl/bdoc/xades/SignatureExtender.java
@@ -33,7 +33,7 @@ import org.digidoc4j.SignatureProfile;
 import org.digidoc4j.exceptions.NotSupportedException;
 import org.digidoc4j.impl.bdoc.BDocSignature;
 import org.digidoc4j.impl.bdoc.BDocSignatureBuilder;
-import org.digidoc4j.impl.bdoc.SkDataLoader;
+import org.digidoc4j.impl.bdoc.dataloader.TimeStampDataLoaderFactory;
 import org.digidoc4j.impl.bdoc.ocsp.SKOnlineOCSPSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import eu.europa.esig.dss.DSSDocument;
 import eu.europa.esig.dss.Policy;
 import eu.europa.esig.dss.SignatureLevel;
+import eu.europa.esig.dss.client.http.DataLoader;
 import eu.europa.esig.dss.client.tsp.OnlineTSPSource;
 import eu.europa.esig.dss.x509.ocsp.OCSPSource;
 
@@ -106,8 +107,7 @@ public class SignatureExtender {
 
   private OnlineTSPSource createTimeStampProviderSource(SignatureProfile profile) {
     OnlineTSPSource tspSource = new OnlineTSPSource(configuration.getTspSource());
-    SkDataLoader dataLoader = SkDataLoader.createTimestampDataLoader(configuration);
-    dataLoader.setUserAgentSignatureProfile(profile);
+    DataLoader dataLoader = new TimeStampDataLoaderFactory(configuration, profile).create();
     tspSource.setDataLoader(dataLoader);
     return tspSource;
   }

--- a/src/org/digidoc4j/impl/bdoc/xades/XadesSigningDssFacade.java
+++ b/src/org/digidoc4j/impl/bdoc/xades/XadesSigningDssFacade.java
@@ -14,6 +14,8 @@ import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Date;
 
+import javax.xml.bind.DatatypeConverter;
+
 import org.digidoc4j.DataFile;
 import org.digidoc4j.impl.bdoc.SKCommonCertificateVerifier;
 import org.digidoc4j.impl.bdoc.asic.DetachedContentCreator;
@@ -68,7 +70,7 @@ public class XadesSigningDssFacade {
   }
 
   public DSSDocument signDocument(byte[] signatureValue, Collection<DataFile> dataFiles) {
-    logger.debug("Signing document with DSS");
+    logger.debug("Signing document with signature value " + DatatypeConverter.printHexBinary(signatureValue));
     SignatureValue dssSignatureValue = new SignatureValue(xAdESSignatureParameters.getSignatureAlgorithm(), signatureValue);
     DetachedContentCreator detachedContentCreator = new DetachedContentCreator().populate(dataFiles);
     DSSDocument dssDocument = detachedContentCreator.getFirstDetachedContent();

--- a/test/org/digidoc4j/impl/bdoc/dataloader/MockDataLoaderFactory.java
+++ b/test/org/digidoc4j/impl/bdoc/dataloader/MockDataLoaderFactory.java
@@ -1,0 +1,31 @@
+/* DigiDoc4J library
+*
+* This software is released under either the GNU Library General Public
+* License (see LICENSE.LGPL).
+*
+* Note that the only valid version of the LGPL license as far as this
+* project is concerned is the original GNU Library General Public License
+* Version 2.1, February 1999
+*/
+
+package org.digidoc4j.impl.bdoc.dataloader;
+
+import eu.europa.esig.dss.client.http.DataLoader;
+
+public class MockDataLoaderFactory implements DataLoaderFactory {
+
+  private DataLoader dataLoader;
+
+  public MockDataLoaderFactory(DataLoader dataLoader) {
+    this.dataLoader = dataLoader;
+  }
+
+  @Override
+  public DataLoader create() {
+    return dataLoader;
+  }
+
+  public DataLoader getDataLoader() {
+    return dataLoader;
+  }
+}

--- a/test/org/digidoc4j/impl/bdoc/ocsp/OcspSourceBuilderTest.java
+++ b/test/org/digidoc4j/impl/bdoc/ocsp/OcspSourceBuilderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertThat;
 
 import org.digidoc4j.Configuration;
 import org.digidoc4j.SignatureProfile;
+import org.digidoc4j.impl.bdoc.SkDataLoader;
 import org.junit.Test;
 
 public class OcspSourceBuilderTest {
@@ -59,6 +60,6 @@ public class OcspSourceBuilderTest {
   private void assertOcspSource(SKOnlineOCSPSource ocspSource, String userAgentPart) {
     assertSame(CONFIGURATION, ocspSource.getConfiguration());
     assertNotNull(ocspSource.getDataLoader());
-    assertThat(ocspSource.getDataLoader().getUserAgent(), containsString(userAgentPart));
+    assertThat(((SkDataLoader)ocspSource.getDataLoader()).getUserAgent(), containsString(userAgentPart));
   }
 }


### PR DESCRIPTION
This change adds the possibility to provide your own data loaders so it would be possible to fine tune network connections to OCSP, TSA and TSL services.

Some integrators would like to control how the network connections are made to fine tune the performance, proxy configurations, timeouts, headers etc (instead of every integrator asking DigiDoc4j team to implement it for them).

It is now possible to create a new DataLoaderFactory for each remote service (OCSP, TSA, TLS) that creates DataLoader instances that control how network connections are made. The factories can be set in the Configuration class.

Here is an example of creating your own data loader for OCSP, TimeStamp and TSL requests:

// Implement a new data loader factory that creates custom data loaders
public class MockDataLoaderFactory implements DataLoaderFactory {
  @Override
  public DataLoader create() {
    return new MockDataLoader();
  }
}
MockDataLoaderFactory mockDataLoaderFactory = new MockDataLoaderFactory();

// Using it for OCSP requests
configuration.setOcspDataLoaderFactory(mockDataLoaderFactory);
// Using it for TimeStamp requests
configuration.setTimestampDataLoaderFactory(mockDataLoaderFactory);
// Using it for TSL requests
configuration.setTslDataLoaderFactory(mockDataLoaderFactory);