### PR TITLE
Support for writing Container directly to OutputStream

### DIFF
--- a/src/org/digidoc4j/Container.java
+++ b/src/org/digidoc4j/Container.java
@@ -282,10 +282,7 @@ public interface Container extends Serializable {
    *
    * @param out output stream.
    * @see java.io.OutputStream
-   * @deprecated will be removed in the future.
-   * @see Container#saveAsStream()
    */
-  @Deprecated
   void save(OutputStream out);
 
   /**

--- a/src/org/digidoc4j/impl/bdoc/BDocContainer.java
+++ b/src/org/digidoc4j/impl/bdoc/BDocContainer.java
@@ -10,6 +10,8 @@
 
 package org.digidoc4j.impl.bdoc;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -83,18 +85,22 @@ public abstract class BDocContainer implements Container {
   public File saveAsFile(String filePath) {
     logger.debug("Saving container to file: " + filePath);
     File file = new File(filePath);
-    AsicContainerCreator zipCreator = new AsicContainerCreator(file);
-    writeAsicContainer(zipCreator);
-    logger.info("Container was saved to file " + filePath);
-    return file;
+    try (OutputStream stream = Helper.bufferedOutputStream(file)) {
+      save(stream);
+      logger.info("Container was saved to file " + filePath);
+      return file;
+    } catch (IOException e) {
+      logger.error("Unable to close stream: " + e.getMessage());
+      throw new TechnicalException("Unable to close stream", e);
+    }
   }
 
   @Override
   public InputStream saveAsStream() {
     logger.debug("Saving container as stream");
-    AsicContainerCreator zipCreator = new AsicContainerCreator();
-    writeAsicContainer(zipCreator);
-    InputStream inputStream = zipCreator.fetchInputStreamOfFinalizedContainer();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    save(outputStream);
+    InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
     logger.info("Container was saved to stream");
     return inputStream;
   }
@@ -169,15 +175,8 @@ public abstract class BDocContainer implements Container {
   }
 
   @Override
-  @Deprecated
   public void save(OutputStream out) {
-    try {
-      InputStream inputStream = saveAsStream();
-      IOUtils.copy(inputStream, out);
-    } catch (IOException e) {
-      logger.error("Error saving container input stream to output stream: " + e.getMessage());
-      throw new TechnicalException("Error saving container input stream to output stream", e);
-    }
+    writeAsicContainer(new AsicContainerCreator(out));
   }
 
   @Override

--- a/src/org/digidoc4j/impl/bdoc/manifest/AsicManifest.java
+++ b/src/org/digidoc4j/impl/bdoc/manifest/AsicManifest.java
@@ -11,6 +11,7 @@
 package org.digidoc4j.impl.bdoc.manifest;
 
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.util.Collection;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -81,11 +82,16 @@ public class AsicManifest {
 
   public byte[] getBytes() {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    writeTo(outputStream);
+    return outputStream.toByteArray();
+  }
+
+  public void writeTo(OutputStream outputStream) {
     DOMImplementationLS implementation = (DOMImplementationLS) dom.getImplementation();
     LSOutput lsOutput = implementation.createLSOutput();
     lsOutput.setByteStream(outputStream);
     LSSerializer writer = implementation.createLSSerializer();
     writer.write(dom, lsOutput);
-    return outputStream.toByteArray();
   }
+
 }

--- a/src/org/digidoc4j/impl/ddoc/DDocContainer.java
+++ b/src/org/digidoc4j/impl/ddoc/DDocContainer.java
@@ -118,7 +118,7 @@ public class DDocContainer implements Container {
   @Override
   public InputStream saveAsStream() {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    jDigiDocFacade.save(outputStream);
+    save(outputStream);
     return new ByteArrayInputStream(outputStream.toByteArray());
   }
 
@@ -267,10 +267,8 @@ public class DDocContainer implements Container {
    *
    * @param out output stream.
    * @see OutputStream
-   * @deprecated will be removed in the future.
    */
   @Override
-  @Deprecated
   public void save(OutputStream out) {
     jDigiDocFacade.save(out);
   }

--- a/src/org/digidoc4j/utils/Helper.java
+++ b/src/org/digidoc4j/utils/Helper.java
@@ -170,6 +170,19 @@ public final class Helper {
     }
   }
 
+  /**
+   * Creates a buffered output stream for a given file.
+   * @param file target file.
+   * @return stream
+   */
+  public static OutputStream bufferedOutputStream(File file) {
+    try {
+      return new BufferedOutputStream(new FileOutputStream(file));
+    } catch (FileNotFoundException e) {
+      throw new DigiDoc4JException(e);
+    }
+  }
+
   /** creates user agent value for given container
    * format is:
    *    LIB DigiDoc4J/VERSION format: CONTAINER_TYPE signatureProfile: SIGNATURE_PROFILE


### PR DESCRIPTION
I see no rationale for `Container.save(OutputStream)` being deprecated. The user should be able to freely choose where to write the contents of the container, be it FileOutputStream, ServletOutputStream or any other.
Another issue I've faced while using the library was the enormous memory usage. I see no point in using byte[] intermediates for ZIP entries in AsicContainerCreator, especially when most of the underlying classes implement some sort of `write(OutputStream)` / `getInputStream()` method.
My solution was to replace `writeZipEntry()` / `writeZipEntryWithoutComment()` with callbacks to the ZipOutputStream. Probably not the most elegant way of doing things, but still less memory overhead and no signature changes.
My implementation uses less than 20 MB of heap for creating a container with a 1.2 GB Modern IE image (checked using VisualVM). The original implementation fails with OutOfMemoryError, if heap is not increased from default 2 GB.