### PR TITLE
Fix bdoc serialization after validation along with timestamp token and ocsp response initialization

### DIFF
--- a/src/org/digidoc4j/impl/bdoc/BDocContainer.java
+++ b/src/org/digidoc4j/impl/bdoc/BDocContainer.java
@@ -50,7 +50,7 @@ public abstract class BDocContainer implements Container {
 
   private static final Logger logger = LoggerFactory.getLogger(BDocContainer.class);
   private Configuration configuration;
-  private ValidationResult validationResult;
+  private transient ValidationResult validationResult;
 
   public BDocContainer() {
     logger.debug("Instantiating BDoc container");

--- a/src/org/digidoc4j/impl/bdoc/xades/TimemarkSignature.java
+++ b/src/org/digidoc4j/impl/bdoc/xades/TimemarkSignature.java
@@ -32,7 +32,7 @@ public class TimemarkSignature extends BesSignature {
 
   private final static Logger logger = LoggerFactory.getLogger(TimemarkSignature.class);
   private X509Cert ocspCertificate;
-  private BasicOCSPResp ocspResponse;
+  private transient BasicOCSPResp ocspResponse;
   private Date ocspResponseTime;
 
   public TimemarkSignature(XadesValidationReportGenerator xadesReportGenerator) {

--- a/src/org/digidoc4j/impl/bdoc/xades/TimestampSignature.java
+++ b/src/org/digidoc4j/impl/bdoc/xades/TimestampSignature.java
@@ -38,7 +38,7 @@ public class TimestampSignature extends TimemarkSignature {
   private final static Logger logger = LoggerFactory.getLogger(TimestampSignature.class);
   private Element signatureElement;
   private XPathQueryHolder xPathQueryHolder;
-  private TimeStampToken timeStampToken;
+  private transient TimeStampToken timeStampToken;
   private X509Cert timestampTokenCertificate;
 
   public TimestampSignature(XadesValidationReportGenerator xadesReportGenerator) {

--- a/test/org/digidoc4j/impl/bdoc/BDocSerializationTest.java
+++ b/test/org/digidoc4j/impl/bdoc/BDocSerializationTest.java
@@ -105,11 +105,12 @@ public class BDocSerializationTest extends DigiDoc4JTestHelper {
   }
 
   @Test
-  public void verifySerializationAfterValidationAndTimestampInitialization() {
+  public void verifySerializationAfterValidationAlongWithTimestampAndOCSPResponseInitialization() {
     Container container = TestDataBuilder.open("testFiles/valid-containers/valid-bdoc-ts-signature-file-name-with-non-numeric-characters.asice");
 
     container.validate();
     container.getSignatures().get(0).getTimeStampCreationTime();
+    container.getSignatures().get(0).getOCSPResponseCreationTime();
 
     serialize(container, serializedContainerPath);
 

--- a/test/org/digidoc4j/impl/bdoc/BDocSerializationTest.java
+++ b/test/org/digidoc4j/impl/bdoc/BDocSerializationTest.java
@@ -105,6 +105,20 @@ public class BDocSerializationTest extends DigiDoc4JTestHelper {
   }
 
   @Test
+  public void verifySerializationAfterValidationAndTimestampInitialization() {
+    Container container = TestDataBuilder.open("testFiles/valid-containers/valid-bdoc-ts-signature-file-name-with-non-numeric-characters.asice");
+
+    container.validate();
+    container.getSignatures().get(0).getTimeStampCreationTime();
+
+    serialize(container, serializedContainerPath);
+
+    Container deserializedContainer = deserializer(serializedContainerPath);
+
+    assertTrue(deserializedContainer.validate().isValid());
+  }
+
+  @Test
   public void serializeExistingContainer() throws Exception {
     Container container = TestDataBuilder.open("testFiles/valid-containers/valid-bdoc-tm.bdoc");
     serialize(container, serializedContainerPath);


### PR DESCRIPTION
In case of bdoc containers when for example either `container.validate()` or `container.getSignatures().get(0).getOCSPResponseCreationTime()` is called before serializing the container, the serialization will fail. When dealing with bdoc timestamp (ASiC-E) containers `container.getSignatures().get(0).getTimeStampCreationTime()` will also produce the same issue.
These changes should fix the problem.
Also added an unit test.