### PR TITLE
made all loggers to static

### DIFF
--- a/digidoc4j/src/main/java/org/digidoc4j/impl/CommonOCSPSource.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/CommonOCSPSource.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CommonOCSPSource extends SKOnlineOCSPSource {
 
-  private final Logger log = LoggerFactory.getLogger(CommonOCSPSource.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommonOCSPSource.class);
 
   /**
    * @param configuration configuration
@@ -24,7 +24,7 @@ public class CommonOCSPSource extends SKOnlineOCSPSource {
 
   @Override
   public Extension createNonce() {
-    this.log.debug("Creating default OCSP nonce ...");
+    LOGGER.debug("Creating default OCSP nonce ...");
     return new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false, new DEROctetString(Helper
         .generateRandomBytes(32)));
   }

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/SKCommonCertificateVerifier.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/SKCommonCertificateVerifier.java
@@ -35,7 +35,7 @@ import eu.europa.esig.dss.x509.ocsp.OCSPSource;
  */
 public class SKCommonCertificateVerifier implements Serializable, CertificateVerifier {
 
-  private final Logger log = LoggerFactory.getLogger(SKCommonCertificateVerifier.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SKCommonCertificateVerifier.class);
   private transient CommonCertificateVerifier commonCertificateVerifier = new CommonCertificateVerifier();
   private transient CertificateSource trustedCertSource;
 
@@ -43,7 +43,7 @@ public class SKCommonCertificateVerifier implements Serializable, CertificateVer
   public CertificateSource getTrustedCertSource() {
     if (this.trustedCertSource instanceof ClonedTslCertificateSource) {
       if (((ClonedTslCertificateSource) this.trustedCertSource).getTrustedListsCertificateSource() != null) {
-        this.log.debug("get TrustedListCertificateSource from ClonedTslCertificateSource");
+        LOGGER.debug("get TrustedListCertificateSource from ClonedTslCertificateSource");
         return ((ClonedTslCertificateSource) this.trustedCertSource).getTrustedListsCertificateSource();
       }
     }
@@ -55,7 +55,7 @@ public class SKCommonCertificateVerifier implements Serializable, CertificateVer
     ClonedTslCertificateSource clonedTslCertificateSource = new ClonedTslCertificateSource(trustedCertSource);
     this.trustedCertSource = clonedTslCertificateSource;
     if (trustedCertSource instanceof LazyTslCertificateSource) {
-      this.log.debug("get TrustedCertSource from LazyTslCertificateSource");
+      LOGGER.debug("get TrustedCertSource from LazyTslCertificateSource");
       this.commonCertificateVerifier.setTrustedCertSource(
           ((LazyTslCertificateSource) trustedCertSource).getTslLoader().getTslCertificateSource());
     } else {

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/SkDataLoader.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/SkDataLoader.java
@@ -38,7 +38,7 @@ import eu.europa.esig.dss.client.http.commons.OCSPDataLoader;
 public class SkDataLoader extends CommonsDataLoader {
 
   private static final String TIMESTAMP_CONTENT_TYPE = "application/timestamp-query";
-  private final Logger log = LoggerFactory.getLogger(SkDataLoader.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SkDataLoader.class);
   private String userAgent;
 
   protected SkDataLoader(Configuration configuration) {
@@ -75,7 +75,7 @@ public class SkDataLoader extends CommonsDataLoader {
     if (StringUtils.isBlank(url)) {
       throw new TechnicalException("SK endpoint url is unset");
     }
-    this.log.debug("Getting OCSP response from <{}>", url);
+    LOGGER.debug("Getting OCSP response from <{}>", url);
     if (StringUtils.isBlank(this.userAgent)) {
       throw new TechnicalException("Header <User-Agent> is unset");
     }

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/TimeStampTokenValidator.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/TimeStampTokenValidator.java
@@ -33,7 +33,7 @@ import eu.europa.esig.dss.DigestAlgorithm;
  */
 public class TimeStampTokenValidator {
 
-  private final Logger log = LoggerFactory.getLogger(TimeStampTokenValidator.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeStampTokenValidator.class);
   private AsicParseResult containerParseResult;
 
   /**
@@ -51,7 +51,7 @@ public class TimeStampTokenValidator {
    * @return ContainerValidationResult
    */
   public ContainerValidationResult validate() {
-    this.log.debug("Validating container ...");
+    LOGGER.debug("Validating container ...");
     this.validateContainer(this.containerParseResult);
     TimeStampToken token = this.getTimeStamp(this.containerParseResult);
     TimeStampContainerValidationResult result = generateTimeStampValidationResult(

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/ocsp/BDocTMOcspSource.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/ocsp/BDocTMOcspSource.java
@@ -17,14 +17,13 @@ import org.slf4j.LoggerFactory;
 
 import eu.europa.esig.dss.DSSUtils;
 import eu.europa.esig.dss.DigestAlgorithm;
-import eu.europa.esig.dss.xades.signature.DSSSignatureUtils;
 
 /**
  * BDocTMOcspSource is class for creating BDoc TM specific NONCE.
  */
 public class BDocTMOcspSource extends SKOnlineOCSPSource {
 
-  private final Logger log = LoggerFactory.getLogger(BDocTMOcspSource.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BDocTMOcspSource.class);
   private final byte[] signature;
 
   /**
@@ -38,7 +37,7 @@ public class BDocTMOcspSource extends SKOnlineOCSPSource {
 
   @Override
   protected Extension createNonce() {
-    this.log.debug("Creating TM OCSP nonce ...");
+    LOGGER.debug("Creating TM OCSP nonce ...");
     try {
       return new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false, this.createSequence().getEncoded());
     } catch (IOException e) {

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/xades/XadesValidationReportGenerator.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/xades/XadesValidationReportGenerator.java
@@ -34,7 +34,7 @@ import eu.europa.esig.dss.xades.validation.XAdESSignature;
 
 public class XadesValidationReportGenerator implements Serializable {
 
-  private final Logger log = LoggerFactory.getLogger(XadesValidationReportGenerator.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(XadesValidationReportGenerator.class);
   private transient SignedDocumentValidator signedDocumentValidator;
   private transient Reports reports;
   private transient XAdESSignature xadesSignature;
@@ -74,7 +74,7 @@ public class XadesValidationReportGenerator implements Serializable {
 
   private Reports generateReports() {
     try {
-      this.log.debug("Creating a new validation report");
+      LOGGER.debug("Creating a new validation report");
       return this.getSignedDocumentValidator().validateDocument(this.getValidationPolicyAsStream());
     } catch (DSSException e) {
       throw new DigiDoc4JException(e);
@@ -89,20 +89,20 @@ public class XadesValidationReportGenerator implements Serializable {
       try {
         return new FileInputStream(policyFile);
       } catch (FileNotFoundException ignore) {
-        this.log.warn(ignore.getMessage());
+        LOGGER.warn(ignore.getMessage());
       }
     }
     return this.getClass().getClassLoader().getResourceAsStream(policyFile);
   }
 
   private XAdESSignature getXAdESSignature() {
-    this.log.debug("Opening XAdES signature");
+    LOGGER.debug("Opening XAdES signature");
     List<AdvancedSignature> signatures = this.getSignedDocumentValidator().getSignatures();
     if (CollectionUtils.isEmpty(signatures)) {
       throw new SignatureNotFoundException("No any XAdES signature found");
     }
     if (signatures.size() > 1) {
-      this.log.warn("Signatures xml file contains more than one XAdES signature. This is not properly supported");
+      LOGGER.warn("Signatures xml file contains more than one XAdES signature. This is not properly supported");
     }
     return (XAdESSignature) signatures.get(0);
   }
@@ -115,17 +115,17 @@ public class XadesValidationReportGenerator implements Serializable {
   }
 
   private SignedDocumentValidator createValidator() {
-    this.log.debug("Creating a new XAdES validator");
+    LOGGER.debug("Creating a new XAdES validator");
     return new XadesValidationDssFacade(this.detachedContents, this.configuration).openXadesValidator(
         this.document);
   }
 
   private void print() {
-    if (this.log.isTraceEnabled()) {
-      this.log.trace("----------------Validation report---------------");
-      this.log.trace(this.reports.getXmlDetailedReport());
-      this.log.trace("----------------Simple report-------------------");
-      this.log.trace(this.reports.getXmlSimpleReport());
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("----------------Validation report---------------");
+      LOGGER.trace(this.reports.getXmlDetailedReport());
+      LOGGER.trace("----------------Simple report-------------------");
+      LOGGER.trace(this.reports.getXmlSimpleReport());
     }
   }
 

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/xades/validation/FullSimpleReportBuilder.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/xades/validation/FullSimpleReportBuilder.java
@@ -18,7 +18,7 @@ import eu.europa.esig.dss.validation.reports.DetailedReport;
  */
 public class FullSimpleReportBuilder {
 
-  private final Logger log = LoggerFactory.getLogger(FullSimpleReportBuilder.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FullSimpleReportBuilder.class);
 
   private static final int BUILDING_BLOCK_ID_LIMIT = 15;
 
@@ -43,7 +43,7 @@ public class FullSimpleReportBuilder {
   }
 
   private void errorsAndWarningsBuilder(){
-    log.debug("Errors and warnings parsing from DetailedReport");
+    LOGGER.debug("Errors and warnings parsing from DetailedReport");
 
     List<XmlBasicBuildingBlocks> basicBuildingBlocks = this.detailedReport.getJAXBModel().getBasicBuildingBlocks();
     List<XmlName> errors = new ArrayList<>();
@@ -131,7 +131,7 @@ public class FullSimpleReportBuilder {
 
   private String transformTypeId(String id) {
     if (id.length() > BUILDING_BLOCK_ID_LIMIT){
-      log.debug("BasicBuildingBlock Id is too big for report: {}", id);
+      LOGGER.debug("BasicBuildingBlock Id is too big for report: {}", id);
       return id.substring(0, BUILDING_BLOCK_ID_LIMIT).concat("..");
     }
     return id;

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/xades/validation/TimemarkSignatureValidator.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/xades/validation/TimemarkSignatureValidator.java
@@ -10,23 +10,15 @@
 
 package org.digidoc4j.impl.asic.xades.validation;
 
-import java.security.cert.X509Certificate;
-import java.util.Date;
-
-import org.apache.commons.lang3.StringUtils;
 import org.digidoc4j.Configuration;
 import org.digidoc4j.exceptions.InvalidTimemarkSignatureException;
-import org.digidoc4j.exceptions.SignedWithExpiredCertificateException;
-import org.digidoc4j.exceptions.UntrustedRevocationSourceException;
 import org.digidoc4j.impl.asic.xades.XadesSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.europa.esig.dss.validation.reports.wrapper.DiagnosticData;
-
 public class TimemarkSignatureValidator extends TimestampSignatureValidator {
 
-    private final Logger log = LoggerFactory.getLogger(TimemarkSignatureValidator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimemarkSignatureValidator.class);
 
     public TimemarkSignatureValidator(XadesSignature signature) {
         super(signature);
@@ -38,9 +30,9 @@ public class TimemarkSignatureValidator extends TimestampSignatureValidator {
 
     @Override
     protected void addPolicyErrors() {
-        this.log.debug("Extracting TM signature policy errors");
+        LOGGER.debug("Extracting TM signature policy errors");
         if (isSignaturePolicyImpliedElementPresented()) {
-            this.log.error("Signature contains forbidden element");
+            LOGGER.error("Signature contains forbidden element");
             this.addValidationError(new InvalidTimemarkSignatureException("Signature contains forbidden <SignaturePolicyImplied> element"));
         }
     }

--- a/digidoc4j/src/main/java/org/digidoc4j/impl/ddoc/DDocSignatureValidationResult.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/ddoc/DDocSignatureValidationResult.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class DDocSignatureValidationResult extends AbstractSignatureValidationResult implements
     ContainerValidationResult {
 
-  private final Logger log = LoggerFactory.getLogger(DDocSignatureValidationResult.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DDocSignatureValidationResult.class);
   private List<DigiDoc4JException> containerExceptions = new ArrayList<>();
   private Document document;
   private Element rootElement;
@@ -135,7 +135,7 @@ public class DDocSignatureValidationResult extends AbstractSignatureValidationRe
       this.errors.add(new DigiDoc4JException(code, message));
       warningOrError = "error";
     }
-    this.log.debug("Validation " + warningOrError + "." + " Code: " + code + ", message: " + message);
+    LOGGER.debug("Validation " + warningOrError + "." + " Code: " + code + ", message: " + message);
     childElement = this.document.createElement(warningOrError);
     childElement.setAttribute("Code", Integer.toString(code));
     childElement.setAttribute("Message", message);

--- a/digidoc4j/src/main/java/org/digidoc4j/main/MultipleContainersExecutor.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/main/MultipleContainersExecutor.java
@@ -29,7 +29,7 @@ import eu.europa.esig.dss.MimeType;
  */
 public class MultipleContainersExecutor {
 
-  private final Logger log = LoggerFactory.getLogger(MultipleContainersExecutor.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MultipleContainersExecutor.class);
   private final CommandLineExecutor commandLineExecutor;
   private Container.DocumentType containerType;
   private File inputDir;
@@ -54,7 +54,7 @@ public class MultipleContainersExecutor {
       if (!document.isDirectory()) {
         this.signDocument(document);
       } else {
-        this.log.debug("Skipping directory " + document.getName());
+        LOGGER.debug("Skipping directory " + document.getName());
       }
     }
   }

--- a/digidoc4j/src/test/java/org/digidoc4j/AbstractTest.java
+++ b/digidoc4j/src/test/java/org/digidoc4j/AbstractTest.java
@@ -66,7 +66,6 @@ public abstract class AbstractTest extends ConfigurationSingeltonHolder {
   @Rule
   public TestWatcher watcher = new TestWatcher() {
 
-    private final Logger log = LoggerFactory.getLogger(AbstractTest.class);
     private long startTimestamp;
 
     @Override

--- a/digidoc4j/src/test/java/org/digidoc4j/ConfigurationTest.java
+++ b/digidoc4j/src/test/java/org/digidoc4j/ConfigurationTest.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertFalse;
 
 public class ConfigurationTest extends AbstractTest {
 
-  private final Logger log = LoggerFactory.getLogger(ConfigurationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationTest.class);
   private static final String SIGN_OCSP_REQUESTS = "SIGN_OCSP_REQUESTS";
   private static final String OCSP_PKCS12_CONTAINER = "DIGIDOC_PKCS12_CONTAINER";
   private static final String OCSP_PKCS_12_PASSWD = "DIGIDOC_PKCS12_PASSWD";
@@ -210,7 +210,7 @@ public class ConfigurationTest extends AbstractTest {
             withConfiguration(this.configuration).build();
         Assert.assertNotEquals(5, container.getConfiguration().getTSL().getCertificates().size());
       } else {
-        this.log.error("Host <{}> is unreachable", tslHost);
+        LOGGER.error("Host <{}> is unreachable", tslHost);
       }
     } catch (Exception e) {
     }


### PR DESCRIPTION
We had serialization exception in our grails application (caused by a non static logger in XadesValidationReportGenerator class) when we were trying to serialize DataToSign class.

