### PR TITLE
DD4J-403 - Should be possible to add TSL certificates with identical public keys

### DIFF
--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/tsl/TSLCertificateSourceImpl.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/tsl/TSLCertificateSourceImpl.java
@@ -87,7 +87,7 @@ public class TSLCertificateSourceImpl extends TrustedListsCertificateSource impl
       tlInfo.setVersion(5);
       updateTlInfo(countryCode, tlInfo);
     }
-    addCertificate(new CertificateToken(certificate), Collections.singletonList(serviceInfo));
+    addCertificate(new CertificateToken(certificate), new ArrayList<>(Arrays.asList(serviceInfo)));
   }
 
   /**

--- a/digidoc4j/src/test/java/org/digidoc4j/ConfigurationTest.java
+++ b/digidoc4j/src/test/java/org/digidoc4j/ConfigurationTest.java
@@ -40,10 +40,16 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.security.cert.CertificateException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.digidoc4j.Constant.BDOC_CONTAINER_TYPE;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
@@ -93,6 +99,27 @@ public class ConfigurationTest extends AbstractTest {
     Assert.assertNotNull(serviceInfostatus.getStartDate());
     Map<String, List<Condition>> qualifiersAndConditions = serviceInfostatus.getQualifiersAndConditions();
     Assert.assertTrue(qualifiersAndConditions.containsKey("http://uri.etsi.org/TrstSvc/TrustedList/SvcInfoExt/QCWithSSCD"));
+  }
+
+  @Test
+  public void addingSameCertificateToTSLMultipleTimes_certNumberRemainsSameButServiceInfoIsDuplicated() {
+    Path certificatePath = Paths.get("src/test/resources/testFiles/certs/Juur-SK.pem.crt");
+    TSLCertificateSource source = new TSLCertificateSourceImpl();
+
+    this.addCertificateToTSL(certificatePath, source);
+    Assert.assertSame(source.getCertificates().size(), 1);
+    CertificateToken certificateToken = source.getCertificates().get(0);
+    Assert.assertSame(source.getTrustServices(certificateToken).size(), 1);
+
+    this.addCertificateToTSL(certificatePath, source);
+    Assert.assertSame(source.getCertificates().size(), 1);
+    certificateToken = source.getCertificates().get(0);
+    Assert.assertSame(source.getTrustServices(certificateToken).size(), 2);
+
+    this.addCertificateToTSL(certificatePath, source);
+    Assert.assertSame(source.getCertificates().size(), 1);
+    certificateToken = source.getCertificates().get(0);
+    Assert.assertSame(source.getTrustServices(certificateToken).size(), 3);
   }
 
   @Test

--- a/digidoc4j/src/test/java/org/digidoc4j/impl/bdoc/ValidationTests.java
+++ b/digidoc4j/src/test/java/org/digidoc4j/impl/bdoc/ValidationTests.java
@@ -720,6 +720,20 @@ public class ValidationTests extends AbstractTest {
     TestAssert.assertContainsError("OCSP Responder does not meet TM requirements", result.getErrors());
   }
 
+  @Test
+  public void sameCertAddedTwiceToTSL_containerValidationShouldSucceed() {
+    Configuration conf = Configuration.of(Configuration.Mode.PROD);
+    conf.setTSL(new TSLCertificateSourceImpl());
+    TestTSLUtil.addCertificateFromFileToTsl(conf, "src/test/resources/prodFiles/certs/ESTEID-SK_2011.pem.crt");
+    TestTSLUtil.addCertificateFromFileToTsl(conf, "src/test/resources/prodFiles/certs/ESTEID-SK_2011.pem.crt");
+    TestTSLUtil.addCertificateFromFileToTsl(conf, "src/test/resources/prodFiles/certs/SK_OCSP_RESPONDER_2011.pem.cer");
+    TestTSLUtil.addCertificateFromFileToTsl(conf, "src/test/resources/prodFiles/certs/SK_TSA.pem.crt");
+    SignatureValidationResult result = this.openContainerByConfiguration(
+            Paths.get("src/test/resources/prodFiles/valid-containers/IB-4183_3.4kaart_RSA2047_TS.asice"), conf).validate();
+    Assert.assertTrue(result.isValid());
+    Assert.assertEquals(0, result.getErrors().size());
+  }
+
   /*
    * RESTRICTED METHODS
    */


### PR DESCRIPTION
Manually adding same certificate twice or certificates with identical public keys to TSL fails due to immutable ServiceInfo collection usage. In DSS the support for such a feature exists - all TSL certificates ServiceInfos are grouped by it's certificate's public key.