### PR TITLE
Avoid NullPointerException if OCSP response certificate chain contains issuer certificates

### DIFF
--- a/digidoc4j/src/main/java/org/digidoc4j/impl/SKOnlineOCSPSource.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/SKOnlineOCSPSource.java
@@ -200,15 +200,34 @@ public abstract class SKOnlineOCSPSource implements OCSPSource {
   private void verifyOCSPResponse(BasicOCSPResp response) throws IOException {
     List<X509CertificateHolder> holders = Arrays.asList(response.getCerts());
     if (CollectionUtils.isNotEmpty(holders)) {
+      boolean hasOcspResponderCert = false;
       for (X509CertificateHolder holder : holders) {
         CertificateToken token = DSSUtils.loadCertificate(holder.getEncoded());
+        if (isOcspResponderCertificate(token)) {
+          hasOcspResponderCert = true;
+        } else {
+          continue;
+        }
         verifyOcspResponderCertificate(token);
         verifyOCSPResponseSignature(token, response);
+      }
+      if(!hasOcspResponderCert) {
+        throw CertificateValidationException.of(CertificateValidationStatus.TECHNICAL,
+            "None of the OCSP response certificates does have 'OCSPSigning' extended key usage");
       }
     } else {
       if (!this.configuration.isTest()) {
         LOGGER.warn("OCSP response signature will not be verified. No response certificates has been found");
       }
+    }
+  }
+
+  protected boolean isOcspResponderCertificate(CertificateToken token) {
+    try {
+      return token.getCertificate().getExtendedKeyUsage() != null && token.getCertificate().getExtendedKeyUsage().contains(OID_OCSP_SIGNING);
+    } catch (CertificateParsingException e) {
+      throw CertificateValidationException.of(CertificateValidationStatus.TECHNICAL,
+          String.format("Error on verifying 'OCSPSigning' extended key usage for OCSP response certificate <%s>", token.getDSSIdAsString()), e);
     }
   }
 


### PR DESCRIPTION
If OCSP response contains issuer certificates without any extended key usages the OCSP verification fails with NullPointerException. 

For example response from http://ocsp.eparaksts.lv for Latvian ID cards issued by CN = LV eID ICA 2017 https://www.eparaksts.lv/cert/LV_eID_ICA_2017.crt

There are 2 certificates returned from response.getCerts(). One of them is OCSP responder, other is not.