### PR TITLE
Allow overriding AsicContainerParser::parseSignatures

### DIFF
--- a/digidoc4j/src/main/java/org/digidoc4j/impl/asic/AsicContainerParser.java
+++ b/digidoc4j/src/main/java/org/digidoc4j/impl/asic/AsicContainerParser.java
@@ -261,18 +261,18 @@ public abstract class AsicContainerParser {
     parseResult.setDataFiles(new ArrayList<>(files));
     parseResult.setCurrentUsedSignatureFileIndex(currentSignatureFileIndex);
     parseResult.setDetachedContents(detachedContents);
-    parseResult.setSignatures(parseSignatures());
     parseResult.setManifestParser(manifestParser);
     parseResult.setZipFileComment(zipFileComment);
     parseResult.setAsicEntries(asicEntries);
     parseResult.setTimeStampToken(timestampToken);
     parseResult.setMimeType(mimeType);
+    parseResult.setSignatures(parseSignatures(configuration, parseResult, signatures));
   }
 
-  private List<XadesSignatureWrapper> parseSignatures() {
-    AsicSignatureParser signatureParser = new AsicSignatureParser(parseResult.getDetachedContents(), configuration);
+  protected List<XadesSignatureWrapper> parseSignatures(Configuration config, AsicParseResult result, List<DSSDocument> sigs) {
+    AsicSignatureParser signatureParser = new AsicSignatureParser(result.getDetachedContents(), config);
     List<XadesSignatureWrapper> parsedSignatures = new ArrayList<>();
-    for (DSSDocument signatureDocument : signatures) {
+    for (DSSDocument signatureDocument : sigs) {
       XadesSignature signature = signatureParser.parse(signatureDocument);
       parsedSignatures.add(new XadesSignatureWrapper(signature, signatureDocument));
     }


### PR DESCRIPTION
Opening an existing container with signatures in the current
version will trigger loading each file fully in memory. If any
of the files does not fit, then the loader will crash with OOM.

Allow overriding parseSignatures so that custom implementations
can implement workarounds such as using DigestDocument for signature
validation.

Signed-off-by: Märt Bakhoff <mbakhoff@sigil.red>